### PR TITLE
Upgrade Hapi, and add log-redaction capabilities

### DIFF
--- a/lib/plugins/config/goodPluginConfig.js
+++ b/lib/plugins/config/goodPluginConfig.js
@@ -13,6 +13,8 @@ class GoodPluginConfig extends VO {
 
     get events() { return this.get('events'); }
 
+    get levels() { return this.get('levels'); }
+
     get opsInterval() { return this.get('opsInterval') }
 }
 

--- a/lib/plugins/config/goodPluginConfig.js
+++ b/lib/plugins/config/goodPluginConfig.js
@@ -15,6 +15,8 @@ class GoodPluginConfig extends VO {
 
     get levels() { return this.get('levels'); }
 
+    get redactedProps() { return this.get('redactedProps'); }
+
     get opsInterval() { return this.get('opsInterval') }
 }
 

--- a/lib/plugins/pluginFactory.js
+++ b/lib/plugins/pluginFactory.js
@@ -60,6 +60,7 @@ class Internals {
             const Good = require('good'); // Logging plugin - https://github.com/hapijs/good
             const GoodWinston = require('good-winston'); // Winston adapter - https://github.com/lancespeelmon/good-winston
             const GoodSqueeze = require('good-squeeze'); // Log filtering - https://github.com/hapijs/good-squeeze
+            const WhiteOut = require('white-out'); // Redact sensitive information: https://github.com/continuationlabs/white-out
 
             const defaultEvents = {
                  log: '*',
@@ -80,11 +81,20 @@ class Internals {
             const events = config.events || defaultEvents;
             const levels = config.levels || defaultLevels;
 
+            // Map of keys to remove/censor from payload before logging.  Values
+            // can be 'censor', 'remove', or a RegExp.
+            // See: https://github.com/continuationlabs/white-out#new-whiteout-filter-options
+            const redactedProps = config.redactedProps || {};
+
             const winstonReporters = [
                 {
                     module: 'good-squeeze',
                     name: 'Squeeze',
                     args: [events]
+                },
+                {
+                    module: 'white-out',
+                    args: [redactedProps]
                 },
                 {
                     module: 'good-winston',

--- a/lib/plugins/pluginFactory.js
+++ b/lib/plugins/pluginFactory.js
@@ -58,22 +58,49 @@ class Internals {
     static addGoodPlugin(config, plugins, logger) {
         if (config.enabled) {
             const Good = require('good'); // Logging plugin - https://github.com/hapijs/good
-            const GoodWinston = require('good-winston');
+            const GoodWinston = require('good-winston'); // Winston adapter - https://github.com/lancespeelmon/good-winston
+            const GoodSqueeze = require('good-squeeze'); // Log filtering - https://github.com/hapijs/good-squeeze
+
             const defaultEvents = {
-                log: '*',
-                request: '*',
-                response: '*',
-                error: '*',
-                ops: '*'
+                 log: '*',
+                 request: '*',
+                 response: '*',
+                 error: '*',
+                 ops: '*'
             };
+
+            const defaultLevels = {
+                error_level: 'error',
+                ops_level: 'debug',
+                request_level:'debug',
+                response_level:'info',
+                other_level: 'info'
+            };
+
             const events = config.events || defaultEvents;
-            const reporters = [new GoodWinston(events, logger.getLogger())];
+            const levels = config.levels || defaultLevels;
+
+            const winstonReporters = [
+                {
+                    module: 'good-squeeze',
+                    name: 'Squeeze',
+                    args: [events]
+                },
+                {
+                    module: 'good-winston',
+                    args: [logger.getLogger(), levels]
+                }
+            ];
 
             plugins.push({
                 register: Good, // Logging! Yay!
                 options: {
-                    reporters: reporters,
-                    opsInterval: config.opsInterval || 1000
+                    reporters: {
+                        winston: winstonReporters
+                    },
+                    ops: {
+                        interval: config.opsInterval || 1000
+                    }
                 }
             });
         }
@@ -174,4 +201,3 @@ class Internals {
         }
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "path": "^0.12.7",
     "poop": "^2.0.0",
     "url": "^0.11.0",
-    "vision": "^4.1.0"
+    "vision": "^4.1.0",
+    "white-out": "^2.0.0"
   },
   "devDependencies": {
     "config-uncached": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -28,16 +28,16 @@
     "async": "^2.0.0-rc.4",
     "blipp": "^2.3.0",
     "config": "^1.20.1",
-    "fs": "0.0.2",
-    "good": "^6.6.3",
-    "good-winston": "^1.0.0",
-    "hapi": "^13.4.0",
+    "good": "^7.1.0",
+    "good-squeeze": "^5.0.1",
+    "good-winston": "^3.0.0",
+    "hapi": "^16.1.0",
     "hapi-router": "^3.5.0",
     "hapi-to": "^1.0.0",
     "hapiest-logger": "^0.1.1",
     "hapiest-vo": "^0.0.4",
     "inert": "^4.0.0",
-    "joi": "^8.1.0",
+    "joi": "^10.2.2",
     "lout": "^9.0.0",
     "path": "^0.12.7",
     "poop": "^2.0.0",
@@ -47,6 +47,7 @@
   "devDependencies": {
     "config-uncached": "^1.0.2",
     "events": "^1.1.0",
-    "should": "^8.3.1"
+    "mocha": "^3.2.0",
+    "should": "^11.2.0"
   }
 }

--- a/test/unit/test-serverFactory.js
+++ b/test/unit/test-serverFactory.js
@@ -2,7 +2,7 @@
 
 const Should = require('should');
 const Async = require('async');
-const EventEmitter = require('events');
+const Server = require('hapi').Server;
 const Path = require('path');
 const NodeConfig = require('config-uncached'); // Need config-uncached so we can reload the config files
 
@@ -27,9 +27,9 @@ const serverDependencies = ServerDependenciesFactory.createDependencies(projectR
 const beforeRoutingPlugins = [];
 
 describe('ServerFactory', function() {
-    
+
     describe('createServer', function() {
-       
+
         it('should return a Hapi server object with one connection at http://localhost:30000', function(done) {
             const config = getBasicHttpServerConfig();
             Async.auto({
@@ -40,7 +40,7 @@ describe('ServerFactory', function() {
                 try {
                     const server = result.server;
 
-                    (server).should.be.an.instanceOf(EventEmitter);
+                    (server).should.be.an.instanceOf(Server);
                     (server).should.have.property('connections');
                     (server.connections.length).should.eql(1);
 
@@ -51,6 +51,7 @@ describe('ServerFactory', function() {
                     (server.info.uri).should.eql('http://localhost:30000');
                     return done();
                 } catch (e) {
+                    console.log(e);
                     return done(e);
                 }
             });
@@ -68,12 +69,11 @@ describe('ServerFactory', function() {
                 try {
                     const server = result.server;
 
-                    (server).should.be.an.instanceOf(EventEmitter);
+                    (server).should.be.an.instanceOf(Server);
                     (server).should.have.property('connections');
                     (server.connections.length).should.eql(2);
 
                     const coreServer = server.select('core');
-                    (coreServer).should.be.an.instanceOf(EventEmitter);
                     (coreServer).should.have.property('connections');
                     (coreServer.connections.length).should.eql(1);
                     (coreServer.connections[0]).should.have.property('info');
@@ -83,7 +83,6 @@ describe('ServerFactory', function() {
                     (coreServer.connections[0].info.uri).should.eql('https://localhost:30000');
 
                     const redirectServer = server.select('redirect');
-                    (redirectServer).should.be.an.instanceOf(EventEmitter);
                     (redirectServer).should.have.property('connections');
                     (redirectServer.connections.length).should.eql(1);
                     (redirectServer.connections[0]).should.have.property('info');
@@ -130,7 +129,7 @@ describe('ServerFactory', function() {
 
                     const server = result.server;
 
-                    (server).should.be.an.instanceOf(EventEmitter);
+                    (server).should.be.an.instanceOf(Server);
                     (server).should.have.property('connections');
                     (server.connections.length).should.eql(1);
 
@@ -160,7 +159,7 @@ describe('ServerFactory', function() {
                 }
             });
         });
-        
+
     });
 
     describe('createServerFromNodeConfig', function() {
@@ -176,7 +175,7 @@ describe('ServerFactory', function() {
                 if (err) { return done(err); }
 
                 try {
-                    (server).should.be.an.instanceOf(EventEmitter);
+                    (server).should.be.an.instanceOf(Server);
                     (server).should.have.property('connections');
                     (server.connections.length).should.eql(1);
 
@@ -204,12 +203,11 @@ describe('ServerFactory', function() {
                 if(err) { done(err); }
 
                 try {
-                    (server).should.be.an.instanceOf(EventEmitter);
+                    (server).should.be.an.instanceOf(Server);
                     (server).should.have.property('connections');
                     (server.connections.length).should.eql(2);
 
                     const coreServer = server.select('core');
-                    (coreServer).should.be.an.instanceOf(EventEmitter);
                     (coreServer).should.have.property('connections');
                     (coreServer.connections.length).should.eql(1);
                     (coreServer.connections[0]).should.have.property('info');
@@ -219,7 +217,6 @@ describe('ServerFactory', function() {
                     (coreServer.connections[0].info.uri).should.eql('https://localhost:3004');
 
                     const redirectServer = server.select('redirect');
-                    (redirectServer).should.be.an.instanceOf(EventEmitter);
                     (redirectServer).should.have.property('connections');
                     (redirectServer.connections.length).should.eql(1);
                     (redirectServer.connections[0]).should.have.property('info');
@@ -237,7 +234,7 @@ describe('ServerFactory', function() {
         });
 
     });
-    
+
 });
 
 /**


### PR DESCRIPTION
* Upgrades Hapi to 16.x [[14.x Changelog](https://github.com/hapijs/hapi/issues/3272)] [[15.x Changelog](https://github.com/hapijs/hapi/issues/3323)] [[16.x Changelog](https://github.com/hapijs/hapi/issues/3398)]
* Upgrades Joi to 10.x  [[9.x Changelog](https://github.com/hapijs/joi/issues/920)] [[10.x Changelog](https://github.com/hapijs/joi/issues/1037)]
* Upgrades Good to 7.x [[7.x Chagelog](https://github.com/hapijs/good/issues/467)]
  * Event filtering is now handled by [`good-squeeze`](https://github.com/hapijs/good-squeeze), but otherwise exposes the same API.
* Upgrades `good-winston` to v3.x, which adds the ability to re-map log levels
* Adds the ability to scrub sensitive information from logs via [`white-out`](https://github.com/continuationlabs/white-out#new-whiteout-filter-options) [[ref](https://github.com/hapijs/good/blob/7a78ec809e4ed1f03bfa7eb67d4968ff79b2c2a4/examples/censoring-with-white-out.md)]

---

Good's plugin config now takes two new options, both of which are optional, and ship with sensible defaults:

`levels` to specify a custom mapping between Hapi events and Winston log levels.  The defaults should be self-explanatory.

```js
levels: {
   error_level: 'error',
   ops_level: 'debug',
   request_level:'debug',
   response_level:'info',
   other_level: 'info'
}
```

`redactProps` to specify properties in log payloads that should be removed or censored prior to being sent to the logger.  See `white-out`'s [filter documentation](https://github.com/continuationlabs/white-out#new-whiteout-filter-options) for full details of what is supported here.

```js
redactProps: {
    propToRedact: 'censor',
    propToRemove: 'remove'
    propToTruncate: '^.{3}'
}
```

---

**Note that this is a semver-MAJOR upgrade**, due to backward-incompatible API changes in Hapi and Joi, which will be exposed to users of this library.

We've internally accommodated the API changes that were introduced by Good v7.  Consumers of `hapiest-server` do not use Good directly, and should not need to make any modifications to their applications to accommodate those changes.